### PR TITLE
Fix initialize for Twitter

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -3,7 +3,7 @@ const process = require('process');
 
 const settings = require('./settings.json');
 
-const client = new Twitter(settings.twitter);
+const client = new Twitter(settings.twitter.auth);
 
 let twitterModule = {};
 twitterModule.post = (text) => {


### PR DESCRIPTION
twitterの初期化時、consumer_keyやconsumer_secretなどの渡し方が違うため、ツイートできないようです。
正しく認証情報を渡せるようにしました(・8・)